### PR TITLE
Add mail merge HTML interface

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -369,3 +369,39 @@ function getEmailsByTag(tag) {
     throw error;
   }
 }
+// Display HTML interface for mail merge
+function showMailMergeDialog() {
+  const html = HtmlService.createHtmlOutputFromFile('MailMerge')
+    .setWidth(600)
+    .setHeight(500);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Send Mail Merge');
+}
+
+// Send personalized emails based on tag
+function sendMailMerge(tag, subject, body) {
+  try {
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Leadership Directory');
+    const data = sheet.getDataRange().getValues();
+    let count = 0;
+    for (let i = 1; i < data.length; i++) {
+      const emailTags = data[i][8];
+      const email = data[i][3];
+      const status = data[i][10];
+      const fullName = data[i][1];
+      if (status === 'Active' && emailTags && emailTags.includes(tag)) {
+        const personalizedBody = body.replace(/{{\s*Full Name\s*}}/g, fullName);
+        MailApp.sendEmail({
+          to: email,
+          subject: subject,
+          htmlBody: personalizedBody
+        });
+        count++;
+      }
+    }
+    return `Sent ${count} emails.`;
+  } catch (error) {
+    console.error('Error sending mail merge:', error);
+    throw error;
+  }
+}
+

--- a/MailMerge.html
+++ b/MailMerge.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body { font-family: Arial, sans-serif; padding: 20px; }
+      .container { max-width: 600px; margin: auto; }
+      h2 { color: #4a90e2; text-align: center; }
+      label { display: block; margin-top: 10px; }
+      input[type="text"], textarea { width: 100%; padding: 8px; box-sizing: border-box; }
+      textarea { height: 150px; }
+      button { margin-top: 15px; padding: 10px 20px; background-color: #4a90e2; color: #fff; border: none; cursor: pointer; }
+      button:hover { background-color: #4178c0; }
+      #status { margin-top: 10px; font-weight: bold; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h2>Send Mail Merge</h2>
+      <label>Tag</label>
+      <input type="text" id="tag" placeholder="e.g. pastor">
+      <label>Subject</label>
+      <input type="text" id="subject">
+      <label>Body (use {{Full Name}} for personalization)</label>
+      <textarea id="body"></textarea>
+      <button onclick="sendMail()">Send</button>
+      <div id="status"></div>
+    </div>
+    <script>
+      function sendMail() {
+        const tag = document.getElementById('tag').value;
+        const subject = document.getElementById('subject').value;
+        const body = document.getElementById('body').value;
+        document.getElementById('status').textContent = 'Sending...';
+        google.script.run.withSuccessHandler(function(msg) {
+          document.getElementById('status').textContent = msg;
+        }).withFailureHandler(function(err) {
+          document.getElementById('status').textContent = 'Error: ' + err.message;
+        }).sendMailMerge(tag, subject, body);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement `showMailMergeDialog` and `sendMailMerge` to send personalized emails
- add new HTML file `MailMerge.html` with a simple styled form

## Testing
- `npm test` *(fails: ENOENT, no package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ea3e00b88322853c963f825ed3d2