### PR TITLE
Add meeting reminder automation with sidebar

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -369,3 +369,95 @@ function getEmailsByTag(tag) {
     throw error;
   }
 }
+/**
+ * Create or get the Meeting Reminders sheet with headers
+ */
+function getReminderSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Meeting Reminders');
+  if (!sheet) {
+    sheet = ss.insertSheet('Meeting Reminders');
+    const headers = ['Meeting Name', 'Next Reminder', 'Recurrence', 'Recipients', 'Message'];
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    sheet.getRange(1, 1, 1, headers.length)
+         .setFontWeight('bold')
+         .setBackground('#4a90e2')
+         .setFontColor('#ffffff')
+         .setHorizontalAlignment('center');
+    sheet.setFrozenRows(1);
+    sheet.setColumnWidths(1, headers.length, 150);
+  }
+  return sheet;
+}
+
+/**
+ * Show sidebar UI for creating a reminder
+ */
+function showReminderSidebar() {
+  const html = HtmlService.createHtmlOutputFromFile('ReminderSidebar')
+    .setTitle('Meeting Reminders');
+  SpreadsheetApp.getUi().showSidebar(html);
+}
+
+/**
+ * Add a new meeting reminder from the sidebar
+ */
+function addMeetingReminder(form) {
+  const sheet = getReminderSheet();
+  sheet.appendRow([
+    form.meetingName,
+    new Date(form.nextReminder),
+    form.recurrence,
+    form.recipients,
+    form.message
+  ]);
+}
+
+/**
+ * Send reminder emails if any are due and update next reminder date
+ */
+function sendMeetingReminders() {
+  const sheet = getReminderSheet();
+  const data = sheet.getDataRange().getValues();
+  const now = new Date();
+
+  for (let i = 1; i < data.length; i++) {
+    let [name, nextReminder, recurrence, recipients, message] = data[i];
+    if (nextReminder && now >= new Date(nextReminder)) {
+      GmailApp.sendEmail(recipients, `Reminder: ${name}`, message);
+
+      // Calculate next reminder date
+      const next = new Date(nextReminder);
+      switch (recurrence) {
+        case 'Daily':
+          next.setDate(next.getDate() + 1);
+          break;
+        case 'Weekly':
+          next.setDate(next.getDate() + 7);
+          break;
+        case 'Monthly':
+          next.setMonth(next.getMonth() + 1);
+          break;
+        default:
+          // no recurrence, clear next reminder to stop sending
+          nextReminder = '';
+          break;
+      }
+
+      // Write next reminder date back
+      sheet.getRange(i + 1, 2).setValue(nextReminder ? next : '');
+    }
+  }
+}
+
+/**
+ * Create a daily trigger for sending reminders
+ */
+function createReminderTrigger() {
+  ScriptApp.newTrigger('sendMeetingReminders')
+    .timeBased()
+    .everyDays(1)
+    .atHour(7)
+    .create();
+}
+

--- a/ReminderSidebar.html
+++ b/ReminderSidebar.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body {font-family: Arial, sans-serif; padding: 10px;}
+      label {display:block;margin-top:8px;}
+      input, textarea, select {width:100%; box-sizing:border-box;}
+      button {margin-top:10px;}
+    </style>
+  </head>
+  <body>
+    <h2>New Meeting Reminder</h2>
+    <form id="reminderForm">
+      <label>Meeting Name
+        <input type="text" name="meetingName" required>
+      </label>
+      <label>Next Reminder (date & time)
+        <input type="datetime-local" name="nextReminder" required>
+      </label>
+      <label>Recurrence
+        <select name="recurrence">
+          <option value="None">None</option>
+          <option value="Daily">Daily</option>
+          <option value="Weekly">Weekly</option>
+          <option value="Monthly">Monthly</option>
+        </select>
+      </label>
+      <label>Recipients (comma separated)
+        <input type="text" name="recipients" required>
+      </label>
+      <label>Message
+        <textarea name="message" rows="4" required></textarea>
+      </label>
+      <button type="submit">Add Reminder</button>
+    </form>
+    <script>
+      const form = document.getElementById('reminderForm');
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        google.script.run.withSuccessHandler(() => {
+          form.reset();
+          alert('Reminder added');
+        }).addMeetingReminder(Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add sidebar HTML UI for creating email meeting reminders
- implement server functions to store reminders in a spreadsheet
- send automatic reminder emails on a schedule via trigger

## Testing
- `node -e "require('fs').readFileSync('Code.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_6844ea80bb48832292b727c509c3ee84