### PR TITLE
Use popup dialog for meeting reminders

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -12,7 +12,7 @@ function onOpen() {
     .addSeparator()
     .addItem('Send Mail Merge…', 'showMailMergeDialog')
     .addSeparator()
-    .addItem('Meeting Reminder Setup…', 'showReminderSidebar')
+    .addItem('Meeting Reminder Setup…', 'showReminderDialog')
     .addItem('Send Meeting Reminders Now', 'sendMeetingReminders')
     .addToUi();
 }

--- a/MeetingReminders.js
+++ b/MeetingReminders.js
@@ -22,12 +22,13 @@ function getReminderSheet() {
 }
 
 /**
- * Show sidebar UI for creating a reminder
+ * Show a popup dialog for creating a reminder
  */
-function showReminderSidebar() {
+function showReminderDialog() {
   const html = HtmlService.createHtmlOutputFromFile('ReminderSidebar')
-    .setTitle('Meeting Reminders');
-  SpreadsheetApp.getUi().showSidebar(html);
+    .setWidth(600)
+    .setHeight(500);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Meeting Reminders');
 }
 
 /**


### PR DESCRIPTION
## Summary
- use `showModalDialog` for creating meeting reminders
- update the menu to call the new dialog method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844f963189c83228f00da295920c901