### PR TITLE
Fix mail merge references

### DIFF
--- a/MailMergeGS.js
+++ b/MailMergeGS.js
@@ -2,7 +2,7 @@
 
 // Display HTML interface for mail merge
 function showMailMergeDialog() {
-  const html = HtmlService.createHtmlOutputFromFile('MailMerge')
+  const html = HtmlService.createHtmlOutputFromFile('MailMergeModal')
     .setWidth(600)
     .setHeight(500);
   SpreadsheetApp.getUi().showModalDialog(html, 'Send Mail Merge');
@@ -34,4 +34,23 @@ function sendMailMerge(tag, subject, body) {
     console.error('Error sending mail merge:', error);
     throw error;
   }
+}
+
+// Retrieve list of tags from the Email Tag Reference sheet
+function getAllTags() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Email Tag Reference');
+  if (!sheet) {
+    return [];
+  }
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) {
+    return [];
+  }
+  const values = sheet.getRange(2, 2, lastRow - 1, 1).getValues();
+  return values.map(r => r[0]).filter(String);
+}
+
+// Backwards compatible name used by older HTML files
+function getAvailableTags() {
+  return getAllTags();
 }

--- a/MailMergeModal.html
+++ b/MailMergeModal.html
@@ -43,18 +43,17 @@
   </div>
 
 <script>
-  const tags = [
-    'regional-director','sales-team','west-coast','board-member','emergency-contact'
-  ];
-
   function populateTags() {
-    const container = document.getElementById('tagList');
-    tags.forEach(tag => {
-      const label = document.createElement('label');
-      label.className = 'flex items-center space-x-1';
-      label.innerHTML = `<input type="checkbox" value="${tag}" class="mr-1"> <span>${tag}</span>`;
-      container.appendChild(label);
-    });
+    google.script.run.withSuccessHandler(tags => {
+      const container = document.getElementById('tagList');
+      container.innerHTML = '';
+      tags.forEach(tag => {
+        const label = document.createElement('label');
+        label.className = 'flex items-center space-x-1';
+        label.innerHTML = `<input type="checkbox" value="${tag}" class="mr-1"> <span>${tag}</span>`;
+        container.appendChild(label);
+      });
+    }).getAllTags();
   }
 
   function loadTemplateOptions() {


### PR DESCRIPTION
## Summary
- rename `MailMerge.js` to `MailMergeGS.js`
- mail merge dialog loads `MailMergeModal.html`
- tags are loaded from the "Email Tag Reference" sheet
- improve tag retrieval if sheet has no data

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845782b90c48322bdb1a076dc776920