### PR TITLE
Fix variable insertion and enable mail sending

### DIFF
--- a/MailMergeGS.js
+++ b/MailMergeGS.js
@@ -9,24 +9,29 @@ function showMailMergeDialog() {
   SpreadsheetApp.getUi().showModalDialog(html, 'Send Mail Merge');
 }
 
-// Send personalized emails based on tag
-function sendMailMerge(tag, subject, body) {
+// Send personalized emails based on one or more tags
+function sendMailMerge(tagOrTags, subject, body) {
   try {
+    const tags = Array.isArray(tagOrTags) ? tagOrTags : [tagOrTags];
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Leadership Directory');
     const data = sheet.getDataRange().getValues();
     let count = 0;
+    const sent = new Set();
     for (let i = 1; i < data.length; i++) {
       const emailTags = data[i][8];
       const email = data[i][3];
       const status = data[i][10];
       const fullName = data[i][1];
-      if (status === 'Active' && emailTags && emailTags.includes(tag)) {
-        const personalizedBody = body.replace(/{{\s*Full Name\s*}}/g, fullName);
+      if (status === 'Active' && emailTags && tags.some(t => emailTags.includes(t)) && !sent.has(email)) {
+        const personalizedBody = body
+          .replace(/{{\s*Full Name\s*}}/g, fullName)
+          .replace(/{{\s*Email\s*}}/g, email);
         MailApp.sendEmail({
           to: email,
           subject: subject,
           htmlBody: personalizedBody
         });
+        sent.add(email);
         count++;
       }
     }

--- a/MailMergeModal.html
+++ b/MailMergeModal.html
@@ -30,6 +30,7 @@
     <div class="flex flex-wrap items-center gap-2 mb-4">
       <button id="insertVarBtn" class="bg-blue-100 text-blue-700 px-2 py-1 rounded">+ Insert Variable</button>
       <select id="variableDropdown" class="border rounded p-1 hidden">
+        <option value="" selected disabled>Select variable</option>
         <option value="{{Full Name}}">{{Full Name}}</option>
         <option value="{{Email}}">{{Email}}</option>
       </select>
@@ -123,9 +124,15 @@
     const selectedTags = Array.from(document.querySelectorAll('#tagList input:checked')).map(cb => cb.value);
     const subject = document.getElementById('subject').value;
     const body = document.getElementById('body').value;
-    const payload = {tags: selectedTags, subject, body};
-    console.log('Sending mail merge', payload);
-    alert('Mail merge payload logged to console');
+    const btn = document.getElementById('sendBtn');
+    btn.disabled = true;
+    google.script.run.withSuccessHandler(msg => {
+      alert(msg);
+      btn.disabled = false;
+    }).withFailureHandler(err => {
+      alert('Error: ' + err.message);
+      btn.disabled = false;
+    }).sendMailMerge(selectedTags, subject, body);
   });
 
   document.getElementById('cancelBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure variable dropdown has a default option so `{{Full Name}}` can be inserted
- call `sendMailMerge` from the modal so emails actually send
- update `sendMailMerge` to handle multiple tags and insert `{{Email}}`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684581ced35083228833664415d3f504