### PR TITLE
Save mail merge templates in sheet

### DIFF
--- a/MailMergeGS.js
+++ b/MailMergeGS.js
@@ -60,3 +60,61 @@ function getAllTags() {
 function getAvailableTags() {
   return getAllTags();
 }
+
+// Get or create the sheet used to store mail merge templates
+function getTemplateSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Mail Templates');
+  if (!sheet) {
+    sheet = ss.insertSheet('Mail Templates');
+    const headers = ['Template Name', 'Subject', 'Body'];
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    sheet.getRange(1, 1, 1, headers.length)
+      .setFontWeight('bold')
+      .setBackground('#4a90e2')
+      .setFontColor('#ffffff')
+      .setHorizontalAlignment('center');
+    sheet.setFrozenRows(1);
+    sheet.setColumnWidths(1, headers.length, 200);
+  }
+  return sheet;
+}
+
+// Save or update a template in the Mail Templates sheet
+function saveMailTemplate(name, subject, body) {
+  const sheet = getTemplateSheet();
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][0] === name) {
+      sheet.getRange(i + 1, 2, 1, 2).setValues([[subject, body]]);
+      return;
+    }
+  }
+  sheet.appendRow([name, subject, body]);
+}
+
+// Retrieve all saved templates
+function listMailTemplates() {
+  const sheet = getTemplateSheet();
+  const data = sheet.getDataRange().getValues();
+  const templates = [];
+  for (let i = 1; i < data.length; i++) {
+    const [name, subject, body] = data[i];
+    if (name) {
+      templates.push({ name, subject, body });
+    }
+  }
+  return templates;
+}
+
+// Retrieve a single template by name
+function getMailTemplate(name) {
+  const sheet = getTemplateSheet();
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (data[i][0] === name) {
+      return { name: data[i][0], subject: data[i][1], body: data[i][2] };
+    }
+  }
+  return null;
+}

--- a/MailMergeModal.html
+++ b/MailMergeModal.html
@@ -59,17 +59,16 @@
   }
 
   function loadTemplateOptions() {
-    const select = document.getElementById('templateSelect');
-    select.innerHTML = '<option value="">-- Select Template --</option>';
-    Object.keys(localStorage).forEach(key => {
-      if (key.startsWith('mailTemplate_')) {
-        const name = key.replace('mailTemplate_', '');
+    google.script.run.withSuccessHandler(templates => {
+      const select = document.getElementById('templateSelect');
+      select.innerHTML = '<option value="">-- Select Template --</option>';
+      templates.forEach(t => {
         const opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
+        opt.value = t.name;
+        opt.textContent = t.name;
         select.appendChild(opt);
-      }
-    });
+      });
+    }).listMailTemplates();
   }
 
   document.getElementById('insertVarBtn').addEventListener('click', () => {
@@ -105,20 +104,21 @@
     if (!name) return;
     const subject = document.getElementById('subject').value;
     const body = document.getElementById('body').value;
-    localStorage.setItem('mailTemplate_' + name, JSON.stringify({subject, body}));
-    loadTemplateOptions();
-    alert('Template saved');
+    google.script.run.withSuccessHandler(() => {
+      loadTemplateOptions();
+      alert('Template saved');
+    }).saveMailTemplate(name, subject, body);
   });
 
   document.getElementById('templateSelect').addEventListener('change', e => {
     const name = e.target.value;
     if (!name) return;
-    const data = localStorage.getItem('mailTemplate_' + name);
-    if (data) {
-      const {subject, body} = JSON.parse(data);
-      document.getElementById('subject').value = subject || '';
-      document.getElementById('body').value = body || '';
-    }
+    google.script.run.withSuccessHandler(t => {
+      if (t) {
+        document.getElementById('subject').value = t.subject || '';
+        document.getElementById('body').value = t.body || '';
+      }
+    }).getMailTemplate(name);
   });
 
   document.getElementById('sendBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- store mail merge templates in dedicated "Mail Templates" sheet
- provide Apps Script helpers to save and load templates
- update modal to load/save templates via Apps Script instead of localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c4a1a3fc8322b0b1eba777462928